### PR TITLE
Minor cleanup on errors and extension handling

### DIFF
--- a/src/ngltf/load.nim
+++ b/src/ngltf/load.nim
@@ -14,30 +14,36 @@ import ./load/json   as loadJson
 
 
 #_____________________________________________________
-proc loadFile *(path :Path; verbose :bool= false) :GLTF=
+proc loadFile *(path :Path; verbose :static bool= false) :GLTF=
   ## Smart load a gltf file into a GLTF object
   ## Reads it as a .glb or .gltf file depending on its extension.
   validate.isGLTF( path )
-  if   verbose: echo &"Loading glTF file from:  {path.string}"
-  if   path.splitFile.ext == ".gltf": result = loadJson.gltf(path)
-  elif path.splitFile.ext == ".glb":  result = loadBinary.gltf(path)
+  when verbose: 
+    echo &"Loading glTF file from:  {path.string}"
+
+  case path.splitFile.ext
+  of ".gltf":
+    loadJson.gltf(path)
+  of ".glb":
+    loadBinary.gltf(path)
   else:
-    echo "WRN: Loading a gltf from {path.string} but its extension {path.string.splitFile.ext} is not known by loadFile(). Treating it as a .glb binary."
-    result = loadBinary.gltf(path)
+    echo &"WRN: Loading a gltf from {path.string} but its extension {path.string.splitFile.ext} is not known by loadFile(). Treating it as a .glb binary."
+    loadBinary.gltf(path)
 #_____________________________________________________
-proc loadMem *(buffer :string; verbose :bool= false; dir :Path= getAppDir().Path) :GLTF=
+proc loadMem *(buffer :string; verbose :static bool= false; dir :Path= getAppDir().Path) :GLTF=
   ## Loads a glb file from the given string bytebuffer into a GLTF object
   ## The input must be self-contained, and not reference any external resources in its buffers.
   ##   eg: Having an URI to load an image not stored in the given glb buffer is not allowed with this function.
   ##       If this limitation is ignored, external files will be searched relative to the main application binary location, unless specified otherwise.
   ##       This path will most likely be incorrect, and lead to an application crash if the glb file does reference external files.
-  if verbose: echo "Loading a glTF from Memory into a GLTF object"
+  when verbose:
+    echo "Loading a glTF from Memory into a GLTF object"
   result = loadBinary.gltf(buffer, dir)
 
 #_____________________________________________________
-proc load *(file :Path; verbose :bool= false) :GLTF=  file.loadFile( verbose )
+proc load *(file :Path; verbose :static bool= false) :GLTF=  file.loadFile( verbose )
   ## Loads a gltf file and returns the specified type of Data object.
-proc load *(input :string; verbose :bool= false; dir = getAppDir().Path) :GLTF=
+proc load *(input :string; verbose :static bool= false; dir = getAppDir().Path) :GLTF=
   ## Smart load a gltf file and returns the specified type of Data object.
   ## Reads it as a file if it exists, or as a bytebuffer if it doesn't.
   ## When the input is a bytebuffer, the data must be self-contained, and not reference any external resources in its buffers.

--- a/src/ngltf/load/buffer.nim
+++ b/src/ngltf/load/buffer.nim
@@ -30,15 +30,16 @@ proc get *(buf :Buffer; _:typedesc[ByteBuffer]; dir :Path; chunk = ByteBuffer())
     result.bytes    = base64.decode( split[1] )
   # Get the data from the file pointed by the URI
   elif buf.uri.isFile():
-    if not fileExists( dir/buf.uri.string.Path ): raise newException(ImportError, "Tried to load Buffer data from {dir/buf.uri.string}, but the file does not exist.")
+    let path = dir / buf.uri.Path
+    if not fileExists( path ): raise newException(ImportError, &"Tried to load Buffer data from {string(path)}, but the file does not exist.")
     result.mimetype = newMimetypes().getMimetype( buf.uri.string.Path.splitFile.ext )
     result.bytes    = readFile( dir/buf.uri.string.Path )
   # Get the buffer data from the given binary chunks data.
   elif buf.uri.isChunk():
-    if chunk.bytes.len < buf.byteLength.int: raise newException(ImportError, &"Tried to load Buffer data from:\n  {buf.uri.string}\n  ...but the length of the given chunk ({chunk.bytes.len}) is less than the length declared in the buffer ({buf.byteLength}).")
+    if chunk.bytes.len < buf.byteLength.int: raise newException(ImportError, &"Tried to load Buffer data from: {buf.uri.string}, but the length of the given chunk ({chunk.bytes.len}) is less than the length declared in the buffer ({buf.byteLength}).")
     result.mimetype = MimetypeGLB
     result.bytes    = chunk.bytes[ 0..<buf.byteLength ]
-  else: raise newException(ImportError, "Tried to load Buffer data from:\n  {buf.uri.string}\n  ...but the input has an unknown or invalid URI format.")
+  else: raise newException(ImportError, &"Tried to load Buffer data from: {buf.uri.string}, but the input has an unknown or invalid URI format.")
   validate.sameLength(buf, result)
 #_______________________________________
 func getData *(buffers :Buffers; view :BufferView) :string=  buffers[ view.buffer ].data.bytes[ view.byteOffset..<view.byteOffset + view.byteLength ]

--- a/src/ngltf/load/texture.nim
+++ b/src/ngltf/load/texture.nim
@@ -29,7 +29,7 @@ proc get *(img :Image; _:typedesc[ByteBuffer]; dir :Path; gltf :GLTF) :ByteBuffe
     let view        = gltf.bufferViews[ img.bufferView ]
     result.bytes    = gltf.buffers.getData(view)
     result.mimetype = img.uri.string
-    if not validate.areSameLength(gltf.buffers[view.buffer], result): raise newException(ImportError, "Tried to load Image data from {img.uri.string}\n  ...but the resulting bytebuffer has a length different than the one declared in the input Image object.")
+    if not validate.areSameLength(gltf.buffers[view.buffer], result): raise newException(ImportError, &"Tried to load Image data from {img.uri.string}, but the resulting bytebuffer has a length different than the one declared in the input Image object.")
   # Get the data from the base64 uri
   elif img.uri.isData():
     let split       = img.uri.string.split(";base64,")
@@ -37,11 +37,12 @@ proc get *(img :Image; _:typedesc[ByteBuffer]; dir :Path; gltf :GLTF) :ByteBuffe
     result.bytes    = base64.decode( split[1] )
   # Get the data from the file
   elif img.uri.isFile():
-    if not fileExists( dir/img.uri.string.Path ): raise newException(ImportError, "Tried to load Image data from {dir/img.uri.string}, but the file does not exist.")
+    let path = dir / img.uri.Path
+    if not fileExists( path ): raise newException(ImportError, &"Tried to load Image data from {string(path)}, but the file does not exist.")
     result.mimetype = newMimetypes().getMimetype( img.uri.string.Path.splitFile.ext )
     result.bytes    = readFile( dir/img.uri.string.Path )
   # Data couldn't be found
-  else: raise newException(ImportError, "Tried to load Image data from:\n  {img.uri.string}\n  ...but the input has an unknown or invalid URI format.")
+  else: raise newException(ImportError, &"Tried to load Image data from: {img.uri.string}, but the input has an unknown or invalid URI format.")
 
 
 #_______________________________________

--- a/src/ngltf/validate.nim
+++ b/src/ngltf/validate.nim
@@ -25,29 +25,29 @@ from   ./types/binary as bin import nil
 proc validate *(header :bin.Header; length :SomeInteger) :void {.inline.}=
   ## Validates that the given header meets all of the required conditions to be a valid glTF header.
   const Magic = bin.Magic
-  if not header.magic      == bin.Magic:   raise newException(ImportError, &"\n  Tried to load a glTF file, but its Magic value ({header.magic}) does not match the glTF specification (should be {Magic}).")
-  if not header.version    == bin.Version: raise newException(ImportError, &"\n  Tried to load a glTF file, but support for version {header.version} is not implemented in ngltf.")
-  if not header.length     >  0:           raise newException(ImportError, &"\n  Tried to load a glTF file, but the length declared in its header is {header.length} and it should be bigger than 0 instead.")
-  if not header.length.int == length.int:  raise newException(ImportError, &"\n  Tried to load a glTF file, but the length declared in its header ({header.length}) does not match the given length sent for validation ({length}).")
+  if not header.magic      == bin.Magic:   raise newException(ImportError, &"Tried to load a glTF file, but its Magic value ({header.magic}) does not match the glTF specification (should be {Magic}).")
+  if not header.version    == bin.Version: raise newException(ImportError, &"Tried to load a glTF file, but support for version {header.version} is not implemented in ngltf.")
+  if not header.length     >  0:           raise newException(ImportError, &"Tried to load a glTF file, but the length declared in its header is {header.length} and it should be bigger than 0 instead.")
+  if not header.length.int == length.int:  raise newException(ImportError, &"Tried to load a glTF file, but the length declared in its header ({header.length}) does not match the given length sent for validation ({length}).")
 #_____________________________
 proc validate *(gltf :JsonNode) :void {.inline.}=
   ## Validates that the given json node contains the fields required to be a valid glTF json object.
   ## Checks that the json has an "asset" and "asset/version" keys, and that the contained version is compatible with ngltf.
-  if not gltf.hasKey("asset"):            raise newException(ImportError, "\n  Tried to load a glTF json file, but the given json doesn't have an asset field (required by spec).")
-  if not gltf["asset"].hasKey("version"): raise newException(ImportError, "\n  Tried to load a glTF json file, but the given json doesn't have a version field (required by spec).")
+  if not gltf.hasKey("asset"):            raise newException(ImportError, "Tried to load a glTF json file, but the given json doesn't have an asset field (required by spec).")
+  if not gltf["asset"].hasKey("version"): raise newException(ImportError, "Tried to load a glTF json file, but the given json doesn't have a version field (required by spec).")
   if not (gltf["asset"]["version"].getStr.parseFloat() == bin.Version.float):
-    raise newException(ImportError, &"\n  Tried to load a glTF json file, but the given node contains an invalid version.")
+    raise newException(ImportError, &"Tried to load a glTF json file, but the given node contains an invalid version.")
 #_____________________________
 proc validate *(chunk :Chunk) :void {.inline.}=
   ## Validates that the given input chunk is valid.
-  if not chunk.length.int == chunk.data.len: raise newException(ImportError, "\n  Tried to load a Chunk from a GLB binary, but its resulting length is different than the one declared in its chunkLength field.")
+  if not chunk.length.int == chunk.data.len: raise newException(ImportError, "Tried to load a Chunk from a GLB binary, but its resulting length is different than the one declared in its chunkLength field.")
 #_____________________________
 proc chunkIDjson *(id :SomeInteger) :void {.inline.}=
   ## Checks that the given id correctly identifies a GltfJson chunk.
-  if not id.uint32 == bin.ChunkIDjson: raise newException(ImportError, &"\n  Tried to load a glTF binary file, but the json chunk id {id} is incorrect (should be {ChunkIDjson})")
+  if not id.uint32 == bin.ChunkIDjson: raise newException(ImportError, &"Tried to load a glTF binary file, but the json chunk id {id} is incorrect (should be {ChunkIDjson})")
 proc chunkIDdata *(id :SomeInteger) :void {.inline.}=
   ## Checks that the given id correctly identifies a GltfData chunk.
-  if not id.uint32 == bin.ChunkIDdata: raise newException(ImportError, &"\n  Tried to load a glTF binary file, but the data chunk id {id} is incorrect (should be {ChunkIDdata})")
+  if not id.uint32 == bin.ChunkIDdata: raise newException(ImportError, &"Tried to load a glTF binary file, but the data chunk id {id} is incorrect (should be {ChunkIDdata})")
 #_____________________________
 func isData  *(uri :URI) :bool=  uri.string.startsWith("data:")
   ## Checks if the given uri string is pointing to a data container.
@@ -58,7 +58,7 @@ func isChunk *(uri :URI) :bool=  uri == UriBufferGLB
 #_____________________________
 proc isGLTF *(path :Path) :void=
   ## Checks that the given path contains a valid gltf file.
-  if not (path.splitFile.ext in ValidGltfFileExtensions): raise newException(ImportError, &"\n  Tried to load glTF from file {path.string}, but it has an incorrect extension (valid options {ValidGltfFileExtensions}).")
+  if not (path.splitFile.ext in ValidGltfFileExtensions): raise newException(ImportError, &"Tried to load glTF from file {path.string}, but it has an incorrect extension (valid options {ValidGltfFileExtensions}).")
 
 #_________________________________________________
 # Buffer
@@ -67,12 +67,12 @@ func areSameLength *(buf :Buffer; bbuf :ByteBuffer) :bool=  buf.byteLength == bb
   ## Returns true if the `buf` Buffer has the same length as the `bbuf` ByteBuffer
 func sameLength *(buf :Buffer; bbuf :ByteBuffer) :void=
   ## Checks that the `buf` Buffer has the same length as the `bbuf` ByteBuffer
-  if not areSameLength(buf, bbuf): raise newException(ImportError, "Tried to load Buffer data from {buf.uri}\n  ...but the resulting bytebuffer has a length ({buf.byteLength}) different than the one declared in the input Buffer object ({bbuf.bytes.len}).")
+  if not areSameLength(buf, bbuf): raise newException(ImportError, &"Tried to load Buffer data from {string buf.uri}, but the resulting bytebuffer has a length ({buf.byteLength}) different than the one declared in the input Buffer object ({bbuf.bytes.len}).")
 func sameLength *(bbuf :ByteBuffer; buf :Buffer) :void=  sameLength( buf, bbuf )
   ## Checks that the `buf` Buffer has the same length as the `bbuf` ByteBuffer
 func sameLength *(acc :Accessor; view :BufferView) :void=
   ## Checks that the given `acc` Accessor defines data that has the same size than the data contained in the buffer portion pointed by the given `view` BufferView.
-  if not (acc.size == view.byteLength):  raise newException(ImportError, &"\n  Tried to access a BufferView from an Accessor that defines data of a size ({acc.size()}) which does not match the bufferView.byteLength ({view.byteLength}).")
+  if not (acc.size == view.byteLength):  raise newException(ImportError, &"Tried to access a BufferView from an Accessor that defines data of a size ({acc.size()}) which does not match the bufferView.byteLength ({view.byteLength}).")
 func sameLength *(view :BufferView; acc :Accessor) :void=  sameLength( acc, view )
   ## Checks that the given `acc` Accessor defines data that has the same size than the data contained in the buffer portion pointed by the given `view` BufferView.
 
@@ -95,9 +95,9 @@ func hasAttr *(meshes :Meshes; key :MeshAttribute) :bool=
   return true
 #_____________________________
 func hasPositions *(mesh :Mesh)  :void=
-  if not mesh.hasAttr( MeshAttribute.pos ): raise newException(ImportError, "\n  Tried to load a Mesh (spec.MeshPrimtive) that has no vertex position information.")
+  if not mesh.hasAttr( MeshAttribute.pos ): raise newException(ImportError, "Tried to load a Mesh (spec.MeshPrimtive) that has no vertex position information.")
 func hasPositions *(mdl  :Model) :void=
-  if not mdl.meshes.hasAttr( MeshAttribute.pos ): raise newException(ImportError, "\n  Tried to load a Model (spec.Mesh) that has no vertex position information in one or more of its meshes (spec.primitives).")
+  if not mdl.meshes.hasAttr( MeshAttribute.pos ): raise newException(ImportError, "Tried to load a Model (spec.Mesh) that has no vertex position information in one or more of its meshes (spec.primitives).")
 #_____________________________
 func hasUVs       *(mdl  :Model) :bool=  mdl.meshes.hasAttr( MeshAttribute.uv )
 func hasUVs       *(mesh :Mesh)  :bool=  mesh.hasAttr( MeshAttribute.uv )


### PR DESCRIPTION
Hopefully you're fine with these changes:
Removed `\n` inside error messages as formatting should be down to what's displaying, if this is in a gui program forced formatting is just ugh.
Made `verbose` a static bool, though perhaps that doesnt make sense.
